### PR TITLE
Don't show title on error messages

### DIFF
--- a/source/jquery.fancybox.js
+++ b/source/jquery.fancybox.js
@@ -1243,7 +1243,7 @@
 		beforeShow: function (opts) {
 			var title, text = F.current.title;
 
-			if (text) {
+			if (text && F.current.content != F.current.tpl.error) {
 				title = $('<div class="fancybox-title fancybox-title-' + opts.type + '-wrap">' + text + '</div>').appendTo('body');
 
 				if (opts.type === 'float') {


### PR DESCRIPTION
title doesn't make much sense when an error message is being shown.  It may be worthwhile to make this configurable
