### PR TITLE
Changed default dataType to HTML

### DIFF
--- a/source/jquery.fancybox.js
+++ b/source/jquery.fancybox.js
@@ -640,6 +640,7 @@
 
 			F.ajaxLoad = $.ajax($.extend({}, F.coming.ajax, {
 				url: F.coming.href,
+				dataType: 'html',
 				error: function (jqXHR, textStatus) {
 					if (textStatus !== 'abort') {
 						F._error( 'ajax', jqXHR );


### PR DESCRIPTION
Changed default dataType to HTML to fix a bug in IE8. It was detecting the wrong dataType in IE and this caused IE not to execute embedded javascript.
