### PR TITLE
Add a X-FancyBox header to AJAX requests

### DIFF
--- a/source/jquery.fancybox.js
+++ b/source/jquery.fancybox.js
@@ -636,6 +636,7 @@
 
 			F.ajaxLoad = $.ajax($.extend({}, F.coming.ajax, {
 				url: F.coming.href,
+				headers: { 'X-FancyBox': true },
 				error: function (jqXHR, textStatus) {
 					if (textStatus !== 'abort') {
 						F._error( 'ajax', jqXHR );


### PR DESCRIPTION
This is very useful when we need to generate a slightly different version of the requested page on the server-side when it will be displayed in a FancyBox.
