### PR TITLE
Allow for selector expressions in URLs.

### DIFF
--- a/source/jquery.fancybox.js
+++ b/source/jquery.fancybox.js
@@ -483,7 +483,8 @@
 				isDom,
 				href,
 				type,
-				rez;
+				rez,
+				hrefParts;
 
 			if (element && (element.nodeType || element instanceof $)) {
 				isDom = true;
@@ -594,10 +595,13 @@
 				}
 
 			*/
-
+			
+			hrefParts = href.split(/\s+/, 2);
+			
 			coming.group = F.group;
 			coming.isDom = isDom;
-			coming.href = href;
+			coming.href = hrefParts.shift();
+			coming.selector = hrefParts.shift();
 
 			if (type === 'image') {
 				F._loadImage();
@@ -742,7 +746,11 @@
 				case 'inline':
 				case 'ajax':
 				case 'html':
-					content = current.content;
+					content
+						= current.selector
+						? $("<div>").html(current.content).find(current.selector).html()
+						: current.content
+						;
 
 					if (content instanceof $) {
 						content = content.show().detach();


### PR DESCRIPTION
This enables a similar behavior to `jQuery.load()', wherein a selector expression can be added to the URL, causing only content matching that expression to be used as dialog content. For example:

```
http://www.example.com/ #content
```

The entire document at "http://www.example.com" will be retrieved, but only the content matching the selector "#content" will be used as dialog content.

This also exposes the property "selector" (in addition to the already-existing "href" property).

See the documentation for `jQuery.load()' for a more detailed description about this behavior:

```
http://api.jquery.com/load/
```
