### PR TITLE
Padding as array

### DIFF
--- a/source/jquery.fancybox.js
+++ b/source/jquery.fancybox.js
@@ -733,6 +733,7 @@
 			{
 				F.outer = $('.fancybox-outer', F.wrap).css('padding', F.current.padding + 'px');
 			}
+
 			F.inner = $('.fancybox-inner', F.wrap);
 
 			F._setContent();
@@ -924,17 +925,17 @@
 			if (current.aspectRatio) {
 				if (width > maxWidth) {
 					width = maxWidth;
-					height = ((width - paddingW) / ratio) + paddingW;
+					height = ((width - paddingW) / ratio) + paddingH;
 				}
 
 				if (height > maxHeight) {
 					height = maxHeight;
-					width = ((height - paddingH) * ratio) + paddingH;
+					width = ((height - paddingH) * ratio) + paddingW;
 				}
 
 				if (width < minWidth) {
 					width = minWidth;
-					height = ((width - paddingW) / ratio) + paddingW;
+					height = ((width - paddingW) / ratio) + paddingH;
 				}
 
 				if (height < minHeight) {


### PR DESCRIPTION
In issue #93 there was a request for paddingLeft, paddingRight... 
I have added the possibility to provide padding in an array the same way you can do it with margin already now.
Syntax: padding: [ top, right, bottom, left ]
Ex: 

``` javascript
$(document).ready(function() {
    $(".fancybox-thumb").fancybox({
        padding: [20, 200, 20, 20]
    });
});
```
