### PR TITLE
Refactor `position: fixed` support retrieval in helpers.overlay.beforeShow()

### DIFF
--- a/source/jquery.fancybox.js
+++ b/source/jquery.fancybox.js
@@ -1616,7 +1616,7 @@
 				overlay.bind('click.fb', F.close);
 			}
 
-			if (F.current.fixed && !isTouch) {
+			if (F.opts.fixed && !isTouch) {
 				overlay.addClass('overlay-fixed');
 
 			} else {


### PR DESCRIPTION
Since we want to already show the overlay when the loading animation is still displayed we assign `overlay.beforeShow` to `overlay.beforeLoad`. But this technique is broken since fancyapps/fancyBox@71f934828180d1c368d0f26944ad96b0633b0b51, because `overlay.beforeShow()` now accesses `F.current`. This can be avoided in this case however since `F.opts.fixed` represents the same value.

Our code:

``` javascript
$.fancybox.helpers.overlay.beforeLoad = $.fancybox.helpers.overlay.beforeShow;
$.fancybox.helpers.overlay.beforeShow = $.noop;
```
