### PR TITLE
Trigger afterShow after arrows and buttons are set

### DIFF
--- a/source/jquery.fancybox.js
+++ b/source/jquery.fancybox.js
@@ -1326,8 +1326,6 @@
 
 			F.wrap.addClass('fancybox-opened').css('overflow', 'visible');
 
-			F.trigger('afterShow');
-
 			F.reposition();
 
 			// Assign a click event
@@ -1354,6 +1352,8 @@
 					$(current.tpl.next).appendTo(F.outer).bind('click.fb', F.next);
 				}
 			}
+
+			F.trigger('afterShow');
 
 			// Start slideshow
 			if (F.opts.autoPlay && !F.player.isActive) {


### PR DESCRIPTION
Upgrading from 2.0.5 to 2.0.6 breaks the assumption that buttons
and arrows are available when afterShow event is triggered.
This brings back 2.0.5 behaviour

I don't know if that is a correct assumption but if there are not
strong objection i think that keep backwards compatibility is
better.
