### PR TITLE
Make default direction for next and prev configurable

### DIFF
--- a/source/jquery.fancybox.js
+++ b/source/jquery.fancybox.js
@@ -111,6 +111,11 @@
 				toggle : [70]  // letter "f" - toggle fullscreen
 			},
 
+			direction : {
+				next: 'down',
+				prev: 'up
+			},
+
 			// Override some properties
 			index   : 0,
 			type    : null,
@@ -455,7 +460,7 @@
 		// Navigate to next gallery item
 		next: function ( direction ) {
 			if (!isString(direction)) {
-				direction = 'down';
+				direction = F.opts.direction.next;
 			}
 
 			if (F.current) {
@@ -466,7 +471,7 @@
 		// Navigate to previous gallery item
 		prev: function ( direction ) {
 			if (!isString(direction)) {
-				direction = 'up';
+				direction = F.opts.direction.prev;
 			}
 
 			if (F.current) {


### PR DESCRIPTION
Don't hardcode default for prev and next action to up and down.
This is helpful when you have the next / prev arrows placed
horizontally and want to do a left / right animation.
