### PR TITLE
Generate unique className so event delegation works regardless of jQuery selector used

### DIFF
--- a/source/jquery.fancybox.js
+++ b/source/jquery.fancybox.js
@@ -1687,7 +1687,8 @@
 	$.fn.fancybox = function (options) {
 		var index,
 			that     = $(this),
-			selector = this.selector || '',
+			fb_class = 'fb_'+ Math.floor( Math.random() * 100000 ), // this class will be added to all thumbs
+			selector = '.'+ fb_class, // use custom class instead of original selector, which may not be usable!
 			run      = function(e) {
 				var what = this, idx = index, relType, relVal;
 
@@ -1718,9 +1719,10 @@
 		options = options || {};
 		index   = options.index || 0;
 
-		if (!selector || options.live === false) {
+		if (options.live === false) {
 			that.unbind('click.fb-start').bind('click.fb-start', run);
 		} else {
+			that.addClass( fb_class );
 			D.undelegate(selector, 'click.fb-start').delegate(selector + ":not('.fancybox-item, .fancybox-nav')", 'click.fb-start', run);
 		}
 


### PR DESCRIPTION
Changed init code so that it no longer uses the original jQuery this.selector, which is not always valid for delegation and therefore can cause fancybox to fail. Instead, a random className is generated for each fancybox instance (eg: "fb_987654"). this generated class is added to all images in the instance, and then is set as the 'selector', eg: selector = ".fb_987654". This gives each instance a unique selector and allows delegation to _always work_ (unless options.live == false).

This changs avoids annoying, hard-to-trace errors like I had when using a selector like this:

```
$("#thumbs-wrapper").children("a").fancybox();
```
