### PR TITLE
Swap the direction of the default transitions

### DIFF
--- a/source/jquery.fancybox.js
+++ b/source/jquery.fancybox.js
@@ -1252,7 +1252,7 @@
 
 				if (current.aspectRatio) {
 					while ((width_ > maxWidth_ || height_ > maxHeight_) && width > minWidth && height > minHeight) {
-						if (steps++ > 19) {
+						if (steps++ > 49) {
 							break;
 						}
 


### PR DESCRIPTION
This creates a more natural feel to the transitions in a gallery. I.e. going right (clicking next button, pressing right arrow key) loads a new image on the right and fades it to the center, previous image fades to the left. Especially visible in thumbnail helper examples.
