### PR TITLE
Added support of data-src attribute to enable graceful degradation when javascript is disabled.

### DIFF
--- a/source/jquery.fancybox.js
+++ b/source/jquery.fancybox.js
@@ -259,7 +259,7 @@
 
 					if (isQuery(element)) {
 						obj = {
-							href    : element.attr('href'),
+							href    : element.data('src') || element.attr('href'),
 							title   : element.attr('title'),
 							isDom   : true,
 							element : element


### PR DESCRIPTION
In the event javascript is disabled, when user clicks the image, it would open the raw url of the image up, now, you can provide a html view of the image in the href and the raw image url for fancyBox in a data-src attribute. If no data-src attribute is available, the href will be used.
