### PR TITLE
Added support for direct Vimeo player URLs in the media helper

### DIFF
--- a/source/helpers/jquery.fancybox-media.js
+++ b/source/helpers/jquery.fancybox-media.js
@@ -29,6 +29,7 @@
  *          http://vimeo.com/40648169
  *          http://vimeo.com/channels/staffpicks/38843628
  *          http://vimeo.com/groups/surrealism/videos/36516384
+ *          http://player.vimeo.com/video/45074303
  *      Metacafe
  *          http://www.metacafe.com/watch/7635964/dr_seuss_the_lorax_movie_trailer/
  *          http://www.metacafe.com/watch/7635964/
@@ -87,7 +88,7 @@
 				url  : '//www.youtube.com/embed/$3'
 			},
 			vimeo : {
-				matcher : /(vimeo.com|vimeopro.com)\/((.*)\/(.*)\/)?(\d+)(#t=\d+)?\/?(.*)/,
+				matcher : /(?:vimeo(?:pro)?.com)\/(?:[^\d]+)?(\d+)(?:.*)/,
 				params  : {
 					autoplay      : 1,
 					hd            : 1,


### PR DESCRIPTION
Hi,

I've just been integrating fancyBox with a client's site and come across an unusual use case; the client hosts their videos on Vimeo, but has hidden them from public view on Vimeo itself. This of course means the media helper doesn't work, because it can't find the video using the standard Vimeo url (which will return a 404).

I've tweaked the href regex slightly so that it matches the direct player/embed URLs as well as the standard ones. In the page we just link directly to the player URL and the helper seems to work nicely again.

I thought this might be a simple tweak you could integrate, in case anyone else encounters this use case.

Kind regards,
Mark B
