### PR TITLE
Add support for Vimeo direct embed URLs to media helper

### DIFF
--- a/source/helpers/jquery.fancybox-media.js
+++ b/source/helpers/jquery.fancybox-media.js
@@ -29,6 +29,7 @@
  *          http://vimeo.com/40648169
  *          http://vimeo.com/channels/staffpicks/38843628
  *          http://vimeo.com/groups/surrealism/videos/36516384
+ *          http://player.vimeo.com/video/45074303
  *      Metacafe
  *          http://www.metacafe.com/watch/7635964/dr_seuss_the_lorax_movie_trailer/
  *          http://www.metacafe.com/watch/7635964/
@@ -87,7 +88,7 @@
 				url  : '//www.youtube.com/embed/$3'
 			},
 			vimeo : {
-				matcher : /(vimeo.com|vimeopro.com)\/((.*)\/(.*)\/)?(\d+)(#t=\d+)?\/?(.*)/,
+				matcher : /(?:vimeo(?:pro)?.com)\/(?:[^\d]+)?(\d+)(?:.*)/,
 				params  : {
 					autoplay      : 1,
 					hd            : 1,
@@ -98,7 +99,7 @@
 					fullscreen    : 1
 				},
 				type : 'iframe',
-				url  : '//player.vimeo.com/video/$5$6'
+				url  : '//player.vimeo.com/video/$1'
 			},
 			metacafe : {
 				matcher : /metacafe.com\/(?:watch|fplayer)\/([\w\-]{1,10})/,


### PR DESCRIPTION
Hi,

I've just been integrating fancyBox with a client's site and come across an unusual use case; the client hosts their videos on Vimeo, but has hidden them from public view on Vimeo itself. This of course means the media helper doesn't work, because it can't find the video using the standard Vimeo url (which will return a 404).

I've tweaked the href regex slightly so that it matches the direct player/embed URLs as well as the standard ones. In the page we just link directly to the player URL and the helper seems to work nicely again.

I thought this might be a simple tweak you could integrate, in case anyone else encounters this use case.

Here are some URLs I used to test the regex, which might come in handy:

```
http://vimeo.com/40648169
http://vimeopro.com/40648169
http://vimeo.com/40648169/
http://vimeo.com/channels/staffpicks/38843628
http://vimeo.com/groups/surrealism/videos/36516384
http://player.vimeo.com/video/45074303
http://vimeo.com/40648169?test=1&test2=2
http://player.vimeo.com/video/40648169#t=1
http://vimeo.com/channels/staffpicks/38843628?t=1
http://vimeo.com/groups/surrealism/videos/36516384#x=0
```

Kind regards,
Mark B
