### PR TITLE
Fix title margin calculation in IE8

### DIFF
--- a/source/jquery.fancybox.js
+++ b/source/jquery.fancybox.js
@@ -34,7 +34,7 @@
 			return (el && !(el.style.overflow && el.style.overflow === 'hidden') && ((el.clientWidth && el.scrollWidth > el.clientWidth) || (el.clientHeight && el.scrollHeight > el.clientHeight)));
 		},
 		getScalar = function(value, dim) {
-			var value_ = parseInt(value, 10);
+			var value_ = ~~value; // Convert to int, default to 0
 
 			if (dim && isPercentage(value)) {
 				value_ = F.getViewport()[ dim ] / 100 * value_;


### PR DESCRIPTION
`title.css('margin-bottom')` returns `auto` in IE8 which is treaded as `NaN` by `parseInt`. Other browsers return `0px` which works fine.

Converting with `~~` is exactly the same as `parseInt(..., 10)` instead of defaulting to 0 for unreadable values.
