### PR TITLE
Fix zooming issue on iOS when switching images

### DIFF
--- a/source/jquery.fancybox.js
+++ b/source/jquery.fancybox.js
@@ -1815,7 +1815,6 @@
 
 					title
 						.appendTo('body')
-						.width(title.width()) //This helps for some browsers
 						.wrapInner('<span class="child"></span>');
 
 						//Increase bottom margin so this title will also fit into viewport


### PR DESCRIPTION
This caused the mobile Safari on the iPad to zoom the window out and caused some serious display glitches.

Tested in: Safari 6, Chrome 21, Firefox 3.6 & 15, Opera 12 and IE 8 & 9.

The comment "This helps for some browsers" doesn't declare what specific browsers this code line was for and it was already part of the initial commit, so we can't say if this is still needed in any other browsers which we haven't tested.
