### PR TITLE
Added support for dynamic titles

### DIFF
--- a/source/jquery.fancybox.js
+++ b/source/jquery.fancybox.js
@@ -280,7 +280,13 @@
 				}
 
 				href  = opts.href  || obj.href || (isString(element) ? element : null);
-				title = opts.title !== undefined ? opts.title : obj.title || '';
+				if (opts.title === undefined) {
+				  title = '';
+				} else if (typeof opts.title === 'function') {
+					title = opts.title.call(element);
+				} else {
+					title = opts.title;
+				}
 
 				content = opts.content || obj.content;
 				type    = content ? 'html' : (opts.type  || obj.type);


### PR DESCRIPTION
I've added support for assigning a function to the title option which allows me to do this.

``` javascript
$(".fancybox").fancybox({
    title: function(element) {
      return element.attr("title") + "<br />" + element.data("detail");
    }
});
```

I'm actually using Underscore.js templates with more sophisticated HTML, but using simple inline HTML is a quick way to illustrate the concept.
