### PR TITLE
removed Invalid CSS property name: -webkit-overflow-scrolling

### DIFF
--- a/source/jquery.fancybox.css
+++ b/source/jquery.fancybox.css
@@ -52,10 +52,6 @@
 	overflow: hidden;
 }
 
-.fancybox-type-iframe .fancybox-inner {
-	-webkit-overflow-scrolling: touch;
-}
-
 .fancybox-error {
 	color: #444;
 	font: 14px/20px "Helvetica Neue",Helvetica,Arial,sans-serif;


### PR DESCRIPTION
Property not exist in Chrome v29.0.1522.0 canary
