### PR TITLE
Fixed Issue #550

### DIFF
--- a/source/jquery.fancybox.js
+++ b/source/jquery.fancybox.js
@@ -546,7 +546,7 @@
 		},
 
 		update: function (e) {
-			var type = (e && e.type),
+			var type = (e && e.originalEvent && e.originalEvent.type),
 				anyway = !type || type === 'orientationchange';
 
 			if (anyway) {


### PR DESCRIPTION
Changed the update function to check for the originalEvent.type
rather than the event.type to be more compatible with other libraries
that could rewrite the default resize event.

Demos:
Before fix:
http://demos.heydanwaz.com/fancybox/no-isotope.html - event and originalEvent are the same
http://demos.heydanwaz.com/fancybox/with-isotope.html - event and originalEvent are different

After:
http://demos.heydanwaz.com/fancybox/with-isotope-fix.html
