### PR TITLE
Enforce redraw of fancybox wrap

### DIFF
--- a/source/jquery.fancybox.js
+++ b/source/jquery.fancybox.js
@@ -1430,7 +1430,7 @@
 
 			F.isOpen = F.isOpened = true;
 
-			F.wrap.css('overflow', 'visible').addClass('fancybox-opened');
+			F.wrap.css('overflow', 'visible').addClass('fancybox-opened').hide().show(0);
 
 			F.update();
 


### PR DESCRIPTION
In Webkit-based browsers, if your mousecursor is exactly at the position
of the next-button while fancybox slides in, you have to click twice to
get to the next image because the first click gets eaten by Webkit to
check the :hover state of the 'a' element used for the next-button.

If we enforce a redraw by doing a hide().show(0), Webkit will reevaluate
the :hover state and the first click will trigger an click event like
expected.
