### PR TITLE
Add support for instagram embed URLs (iframe)

### DIFF
--- a/source/helpers/jquery.fancybox-media.js
+++ b/source/helpers/jquery.fancybox-media.js
@@ -149,6 +149,15 @@
 				type : 'image',
 				url  : '//twitpic.com/show/full/$1/'
 			},
+			instagram_embed : {
+				matcher : /(instagr\.am|instagram\.com)\/p\/([a-zA-Z0-9_\-]+)\/embed\/?/i,
+				type: 'iframe',
+				url: '//$0',
+				opts: {
+					width: 612,
+					height: 720
+				}
+			},
 			instagram : {
 				matcher : /(instagr\.am|instagram\.com)\/p\/([a-zA-Z0-9_\-]+)\/?/i,
 				type : 'image',
@@ -169,7 +178,8 @@
 				what,
 				item,
 				rez,
-				params;
+				params,
+				extraOpts;
 
 			for (what in opts) {
 				if (opts.hasOwnProperty(what)) {
@@ -182,6 +192,8 @@
 
 						url = $.type( item.url ) === "function" ? item.url.call( this, rez, params, obj ) : format( item.url, rez, params );
 
+						extraOpts = item.opts;
+
 						break;
 					}
 				}
@@ -190,6 +202,10 @@
 			if (type) {
 				obj.href = url;
 				obj.type = type;
+				
+				if($.type(extraOpts) == 'object') {
+					$.extend(true, obj, extraOpts);
+				}
 
 				obj.autoHeight = false;
 			}


### PR DESCRIPTION
We ran into an issue where the media helper detects instagram "embed" URLs as regular Instagram images which overrides passing the type as "iframe". This patch adds:
- support for embed URLs (instagram.com/p/<ID>/embed/) and also provides some sensible defaults for sizing Fancybox to fit the contents
- An extra "opts" object can be added to media helper configs to allow arbitrary options to be merged on to the current item (width and height in this case)
