### PR TITLE
Updated youtube matcher for more support

### DIFF
--- a/source/helpers/jquery.fancybox-media.js
+++ b/source/helpers/jquery.fancybox-media.js
@@ -89,7 +89,7 @@
 	F.helpers.media = {
 		defaults : {
 			youtube : {
-				matcher : /(youtube\.com|youtu\.be|youtube-nocookie\.com)\/(watch\?v=|v\/|u\/|embed\/?)?(videoseries\?list=(.*)|[\w-]{11}|\?listType=(.*)&list=(.*)).*/i,
+				matcher : /(youtube\.com|youtube\.com\/watch\?feature=player_embedded|youtu\.be|youtube-nocookie\.com)\/(watch\?v=|v\/|u\/|embed\/?)?(videoseries\?list=(.*)|[\w-]{11}|\?listType=(.*)&list=(.*)).*/i,
 				params  : {
 					autoplay    : 1,
 					autohide    : 1,


### PR DESCRIPTION
The problem was that the Youtube matcher didn't expect to have `feature=player_embedded` in the parameters (eg.
`http://www.youtube.com/watch?feature=player_embedded&v=sigvvcnNpoo`) so I have added this to the Youtube matcher: `youtube\.com\/watch\?feature=player_embedded`
