### PR TITLE
Fix twice loading of image

### DIFF
--- a/source/jquery.fancybox.js
+++ b/source/jquery.fancybox.js
@@ -949,7 +949,7 @@
 				F.coming.width  = this.width / F.opts.pixelRatio;
 				F.coming.height = this.height / F.opts.pixelRatio;
 
-				F._afterLoad();
+				F._afterLoad(img);
 			};
 
 			img.onerror = function () {
@@ -959,6 +959,7 @@
 			};
 
 			img.src = F.coming.href;
+			img.className = 'fancybox-image';
 
 			if (img.complete !== true) {
 				F.showLoading();
@@ -1047,7 +1048,7 @@
 			}
 		},
 
-		_afterLoad: function () {
+		_afterLoad: function (element) {
 			var coming   = F.coming,
 				previous = F.current,
 				placeholder = 'fancybox-placeholder',
@@ -1083,7 +1084,6 @@
 			F.unbindEvents();
 
 			current   = coming;
-			content   = coming.content;
 			type      = coming.type;
 			scrolling = coming.scrolling;
 
@@ -1096,45 +1096,50 @@
 				previous : previous
 			});
 
-			href = current.href;
-
-			switch (type) {
-				case 'inline':
-				case 'ajax':
-				case 'html':
-					if (current.selector) {
-						content = $('<div>').html(content).find(current.selector);
-
-					} else if (isQuery(content)) {
-						if (!content.data(placeholder)) {
-							content.data(placeholder, $('<div class="' + placeholder + '"></div>').insertAfter( content ).hide() );
-						}
-
-						content = content.show().detach();
-
-						current.wrap.bind('onReset', function () {
-							if ($(this).find(content).length) {
-								content.hide().replaceAll( content.data(placeholder) ).data(placeholder, false);
+			if (element) {
+				content	= element;
+			} else {
+				href	= current.href;
+				content = coming.content;
+	
+				switch (type) {
+					case 'inline':
+					case 'ajax':
+					case 'html':
+						if (current.selector) {
+							content = $('<div>').html(content).find(current.selector);
+	
+						} else if (isQuery(content)) {
+							if (!content.data(placeholder)) {
+								content.data(placeholder, $('<div class="' + placeholder + '"></div>').insertAfter( content ).hide() );
 							}
+	
+							content = content.show().detach();
+	
+							current.wrap.bind('onReset', function () {
+								if ($(this).find(content).length) {
+									content.hide().replaceAll( content.data(placeholder) ).data(placeholder, false);
+								}
+							});
+						}
+					break;
+	
+					case 'image':
+						content = current.tpl.image.replace(/\{href\}/g, href);
+					break;
+	
+					case 'swf':
+						content = '<object id="fancybox-swf" classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="100%" height="100%"><param name="movie" value="' + href + '"></param>';
+						embed   = '';
+	
+						$.each(current.swf, function(name, val) {
+							content += '<param name="' + name + '" value="' + val + '"></param>';
+							embed   += ' ' + name + '="' + val + '"';
 						});
-					}
-				break;
-
-				case 'image':
-					content = current.tpl.image.replace(/\{href\}/g, href);
-				break;
-
-				case 'swf':
-					content = '<object id="fancybox-swf" classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="100%" height="100%"><param name="movie" value="' + href + '"></param>';
-					embed   = '';
-
-					$.each(current.swf, function(name, val) {
-						content += '<param name="' + name + '" value="' + val + '"></param>';
-						embed   += ' ' + name + '="' + val + '"';
-					});
-
-					content += '<embed src="' + href + '" type="application/x-shockwave-flash" width="100%" height="100%"' + embed + '></embed></object>';
-				break;
+	
+						content += '<embed src="' + href + '" type="application/x-shockwave-flash" width="100%" height="100%"' + embed + '></embed></object>';
+					break;
+				}
 			}
 
 			if (!(isQuery(content) && content.parent().is(current.inner))) {


### PR DESCRIPTION
if we call

``` js
$.fancybox.open('/path/to/img.png');
```

Image loads twice in functions:
- [_loadImage](https://github.com/fancyapps/fancyBox/blob/master/source/jquery.fancybox.js#L961)
- [_afterLoad](https://github.com/fancyapps/fancyBox/blob/master/source/jquery.fancybox.js#L1141)

You could see this in screenshot. Or on this [link](http://io.cloudcmd.io/fs/home/io/cloudcmd/img/screen#/view/console.png).
![fancybox-bug-twice-loading-of-image](https://cloud.githubusercontent.com/assets/1573141/2589872/03faff50-ba53-11e3-8a94-90103590b5ce.png)

When you use construction  

``` js
new Image().src = '/path/to/img.png';
```

Image start load. Then when you use construction

``` js
$(element).append('<img src="/path/to/img.png"');
```

It's loads second time. This have no sense.

To prevent this, I add parameter `element` to function `_afterLoad`. So if `image element` was created it puts the element as parameter and appends it without additional parsing and loading of image.
