### PR TITLE
Add support for Turbolinks

### DIFF
--- a/source/jquery.fancybox.js
+++ b/source/jquery.fancybox.js
@@ -1970,7 +1970,7 @@
 	};
 
 	// Tests that need a body at doc ready
-	D.ready(function() {
+	D.on('ready page:load', function() {
 		var w1, w2;
 
 		if ( $.scrollbarWidth === undefined ) {


### PR DESCRIPTION
Turbolinks is not compatible with fancybox: its ok when we load the page for the first time, but brokens when we change between pages (by clicking on links).

The problem is because part of fancybox initialization process is executed when the "ready" event its triggered, but Turbolinks doesn't trigger "ready" when we change between pages - so some initialization will be never executed. Instead of trigger "ready", Turbolinks triggers a custom event called "page:load".

This PR listen to the "page:load" event too and executes the initialization process correctly, without affect another frameworks/existent/legacy code. Its just adds a support without affect existent code.

PS: Turbolinks it's a core part of the well-know Rails framework. github.com itself runs on Rails and when we had clicked on the link to this page, Turbolinks was called. By the way, this very page doesn't had triggered a "ready" event, but a "page:load" one.

This resolves the issue #710
