### PR TITLE
Youtube play button doesn't work on mobile devices

### DIFF
--- a/source/helpers/jquery.fancybox-media.js
+++ b/source/helpers/jquery.fancybox-media.js
@@ -97,7 +97,9 @@
 					rel         : 0,
 					hd          : 1,
 					wmode       : 'opaque',
-					enablejsapi : 1
+					enablejsapi : 1,
+                    			ps: 'docs',
+                    			controls: 1
 				},
 				type : 'iframe',
 				url  : '//www.youtube.com/embed/$3'


### PR DESCRIPTION
i found that it's missing the controls and ps params on the youtube iframe src url so in line 100 of fancybox media helper file i added it and now it's working fine.
ps: 'docs',
controls: 1