### PR TITLE
fixed #971 - media helper not loading youtube videos

### DIFF
--- a/source/helpers/jquery.fancybox-media.js
+++ b/source/helpers/jquery.fancybox-media.js
@@ -183,7 +183,7 @@
 						params = $.extend(true, {}, item.params, obj[ what ] || ($.isPlainObject(opts[ what ]) ? opts[ what ].params : null));
 
 						url = $.type( item.url ) === "function" ? item.url.call( this, rez, params, obj ) : format( item.url, rez, params );
-
+						url = "http:" + url;
 						break;
 					}
 				}


### PR DESCRIPTION
This fixes the issue of youtube videos not loading with the media helper. Before, it would try to load the video locally, but this fixes it so that it actually loads the proper link. @finion's proposed solution from #971 worked, but it appears that no pull request was ever filed for it.
