### PR TITLE
Add Gulp support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .project
 .settings
+dist/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,76 @@
+/* jshint node: true */
+/* global $: true */
+"use strict";
+
+var gulp = require("gulp"),
+    $ = require("gulp-load-plugins")();
+var config = {
+        js: [
+            "lib/jquery.mousewheel.pack.js",
+            "source/jquery.fancybox.pack.js",
+            "source/helpers/jquery.fancybox-buttons.js",
+            "source/helpers/jquery.fancybox-thumbs.js",
+            "source/helpers/jquery.fancybox-media.js"
+        ],
+        css: [
+            "source/jquery.fancybox.css",
+            "source/helpers/jquery.fancybox-buttons.css",
+            "source/helpers/jquery.fancybox-thumbs.css"
+        ],
+        images: [
+            "source/helpers/**/*.{jpg,png,svg,gif,webp,ico}",
+            "source/*.{jpg,png,svg,gif,webp,ico}"
+        ]
+    },
+    dist = {
+        images: "dist/images/fancybox",
+        css: "dist/css",
+        js: "dist/js"
+    };
+
+
+/*
+ - |--------------------------------------------------------------------------
+ - | Gulp Front Tasks
+ - |--------------------------------------------------------------------------
+ - |
+ + *
+ + *
+ */
+
+gulp.task("clean", function () {
+    return gulp.src("dist", {read: false})
+        .pipe($.clean());
+});
+
+gulp.task("scripts", function () {
+    return gulp.src(config.js)
+        .pipe($.plumberNotifier())
+        .pipe($.concat("jquery.fancybox.min.js"))
+        .pipe($.uglify())
+        .pipe(gulp.dest(dist.js));
+});
+
+gulp.task("styles", function () {
+    return gulp.src(config.css)
+        .pipe($.plumberNotifier())
+        .pipe($.concat("jquery.fancybox.min.css"))
+        .pipe($.autoprefixer("last 5 version"))
+        .pipe($.replace(/url\('?(.*)'?\)/g, "url('../images/fancybox/$1')"))
+        .pipe($.replace("''", "'"))
+        .pipe($.cleanCss({compatibility: 'ie8'}))
+        .pipe(gulp.dest(dist.css))
+});
+
+gulp.task("images", function () {
+    return gulp.src(config.images)
+        .pipe($.newer(dist.images))
+        .pipe(gulp.dest(dist.images));
+});
+
+
+gulp.task('default', ["images", "styles", "scripts"]);
+
+
+
+ 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "fancybox",
+  "title": "fancyBox",
+  "description": "fancyBox offers an elegant way to present images, html content and multimedia for webpages",
+  "keywords": [
+    "lightbox",
+    "effect",
+    "responsive",
+    "modal",
+    "window",
+    "ui"
+  ],
+  "licenses": [
+    {
+      "type": "fancyBox",
+      "url": "http://fancyapps.com/fancybox/#license"
+    }
+  ],
+  "version": "2.1.5",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fancyapps/fancyBox"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "del": "^0.1.2",
+    "gulp": "^3.6.0",
+    "gulp-autoprefixer": "0.0.7",
+    "gulp-clean": "^0.3.2",
+    "gulp-clean-css": "^2.0.4",
+    "gulp-concat": "^2.3.4",
+    "gulp-csso": "^0.2.9",
+    "gulp-jshint": "^1.8.4",
+    "gulp-load-plugins": "^0.5.0",
+    "gulp-newer": "^1.1.0",
+    "gulp-plumber": "^1.1.0",
+    "gulp-plumber-notifier": "0.0.3",
+    "gulp-rename": "^1.2.2",
+    "gulp-replace": "^0.5.4",
+    "gulp-sass": "^2.2.0",
+    "gulp-uglify": "^1.0.0",
+    "gulp-util": "^3.0.7"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  }
+}


### PR DESCRIPTION
This Patch just adds gulp support to fancybox, so developers can create a minified, and single css and javascript version on demand.

Developers can easily comment out optional css and javascripts in gulpfile, to get the final code without them.
```
var config = {
        js: [
            "lib/jquery.mousewheel.pack.js",
            "source/jquery.fancybox.pack.js",
            "source/helpers/jquery.fancybox-buttons.js",
            //"source/helpers/jquery.fancybox-thumbs.js",
            //"source/helpers/jquery.fancybox-media.js"
        ],
        css: [
            "source/jquery.fancybox.css",
            "source/helpers/jquery.fancybox-buttons.css",
            //"source/helpers/jquery.fancybox-thumbs.css"
        ],
        images: [
            "source/helpers/**/*.{jpg,png,svg,gif,webp,ico}",
            "source/*.{jpg,png,svg,gif,webp,ico}"
        ]
    } 
```