### PR TITLE
Fix for breaking change in jQuery 3

### DIFF
--- a/source/helpers/jquery.fancybox-thumbs.js
+++ b/source/helpers/jquery.fancybox-thumbs.js
@@ -69,7 +69,7 @@
 					return;
 				}
 
-				$("<img />").load(function () {
+				$("<img />").on("load", function () {
 					var width  = this.width,
 						height = this.height,
 						widthRatio, heightRatio, parent;


### PR DESCRIPTION
the .load method has been removed from jquery 3, in favor of using `obj.on("load", function())`

See also issue #1149 