### PR TITLE
Use show without animation

### DIFF
--- a/source/jquery.fancybox.js
+++ b/source/jquery.fancybox.js
@@ -1431,7 +1431,7 @@
 
 			F.isOpen = F.isOpened = true;
 
-			F.wrap.css('overflow', 'visible').addClass('fancybox-opened').hide().show(0);
+			F.wrap.css('overflow', 'visible').addClass('fancybox-opened').hide().show();
 
 			F.update();
 


### PR DESCRIPTION
Hi. I've found out that `show(0)` uses animation and not showing `F.wrap` and putting it to animation queue, which makes element invisible while `F.update();`.
This pr fixes that issue and I suppose support case https://github.com/fancyapps/fancybox/commit/46f3dc5a5e5171add76c0d8f8247a4ba96017b0f which it was added for.