### PR TITLE
Support for the iframe attribute srcdoc

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -612,6 +612,10 @@
                         opts.image = { srcset : data.srcset };
                     }
 
+                    if ( 'srcdoc' in data ) {
+                        opts.iframe = { srcdoc : data.srcdoc };
+                    }
+
                     opts.$orig = $item;
 
                     if ( !obj.type && !obj.src ) {
@@ -1862,6 +1866,10 @@
             }
 
             $iframe.attr( 'src', slide.src );
+
+            if ( 'srcdoc' in slide.opts.iframe ) {
+                $iframe.attr( 'srcdoc', slide.opts.iframe.srcdoc );
+            }
 
             if ( slide.opts.smallBtn === true ) {
                 slide.$content.prepend( self.translate( slide, slide.opts.btnTpl.smallBtn ) );


### PR DESCRIPTION
HTML5 introduced the iframe attribute srcdoc, allowing the iframe content to be specified in the html source instead of relying on an url. This commit implements support for the srcdoc attribute.

Initialize with data attributes:

    <a data-fancybox data-type="iframe" data-srcdoc="&lt;p&gt;Your content here&lt;/p&gt;" href="javascript:;">Open</a>

Initialize with JavaScript:

    $("[data-fancybox]").fancybox({
        iframe: { srcdoc: "<p>Your content here</p>" }
    });