### PR TITLE
Make sure an instance of Fancybox exists when handling fullscreen change

### DIFF
--- a/src/js/fullscreen.js
+++ b/src/js/fullscreen.js
@@ -175,7 +175,9 @@
 
 	$(document).on(fn.fullscreenchange, function() {
 		var instance = $.fancybox.getInstance();
-
+		if ( instance === false ) {
+			return; // there is no fancybox instance, so do not continue
+		}
 		// If image is zooming, then force to stop and reposition properly
 		if ( instance.current && instance.current.type === 'image' && instance.isAnimating ) {
 			instance.current.$content.css( 'transition', 'none' );


### PR DESCRIPTION
I came across a scenario that Fancybox throws an exception when another feature (ie. google maps) uses the full screen mode. 

The event listener of Fancybox gets triggered, and `getInstance()` returns `false` since there is no box currently open. As a result, the following exception is thrown:

```
Uncaught TypeError: instance.trigger is not a function
```