### PR TITLE
fix jQuery not found in webpack

### DIFF
--- a/src/js/thumbs.js
+++ b/src/js/thumbs.js
@@ -249,4 +249,4 @@
 
 	});
 
-}(document, window.jQuery));
+}(document, window.jQuery || jQuery));


### PR DESCRIPTION
when you use fancy in webpack, you receive the error that jQuery not found