### PR TITLE
Update project URL to current version (fancyBox 3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fancyapps/fancybox",
   "description": "Touch enabled, responsive and fully customizable jQuery lightbox script",
   "version": "3.3.5",
-  "homepage": "http://fancyapps.com/fancybox/",
+  "homepage": "https://fancyapps.com/fancybox/3/",
   "main": "./dist/jquery.fancybox.js",
   "author": "fancyApps",
   "license": "GPL-3.0",


### PR DESCRIPTION
This was still linking to the deprecated fancyBox v2 website.