### PR TITLE
Fix for thumbnail url that contains spaces

### DIFF
--- a/src/js/thumbs.js
+++ b/src/js/thumbs.js
@@ -117,7 +117,7 @@
             '" tabindex="0" class="' +
             CLASS_LOAD +
             '"' +
-            (src && src.length ? ' style="background-image:url(' + src + ')" />' : "") +
+            (src && src.length ? ' style="background-image:url(\'' + src + '\')" />' : "") +
             "></li>"
         );
       });


### PR DESCRIPTION
Without apostrophes thumbnails do not display