### PR TITLE
Adjust test for isMobile to work on newer devices

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -2803,8 +2803,7 @@
     // Try to detect mobile devices
     // ============================
 
-    isMobile:
-      document.createTouch !== undefined && /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent),
+    isMobile: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent),
 
     // Detect if 'translate3d' support is available
     // ============================================


### PR DESCRIPTION
The `isMobile` detection relies on document.createTouch, which
is deprecated and not available on newer devices (e.g. newest Chrome
on Android). As there is no real alternative and detecting touch
is hard / impossible, resort to UA sniffing only.

See: https://developer.mozilla.org/en-US/docs/Web/API/Document/createTouch#Browser_compatibility