### PR TITLE
Fix documentation for base tpl

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -977,9 +977,9 @@ parent.jQuery.fancybox.getInstance().update();
     '&lt;div class=&quot;fancybox-toolbar&quot;&gt;{{buttons}}&lt;/div&gt;' +
     '&lt;div class=&quot;fancybox-navigation&quot;&gt;{{arrows}}&lt;/div&gt;' +
     '&lt;div class=&quot;fancybox-stage&quot;&gt;&lt;/div&gt;' +
-    '&lt;div class=&quot;fancybox-caption&quot;&gt;&lt;/div&gt;' +
-    &quot;&lt;/div&gt;&quot; +
-    &quot;&lt;/div&gt;&quot;,
+    '&lt;div class=&quot;fancybox-caption&quot;&gt;&lt;div class="&quot;fancybox-caption__body&quot;&gt;&lt;/div&gt;&lt;/div&gt;' +
+    '&lt;/div&gt;'; +
+    '&lt;/div&gt;',
 
   // Loading indicator template
   spinnerTpl: '&lt;div class=&quot;fancybox-loading&quot;&gt;&lt;/div&gt;',


### PR DESCRIPTION
The base tpl in the docs is missing the caption body, which causes it to break if you use a custom tpl - even if it is the same as the one in the docs