### PR TITLE
Fixed deprecated .focus() in hash.js

### DIFF
--- a/src/js/hash.js
+++ b/src/js/hash.js
@@ -52,7 +52,7 @@
       // then triggering click event should start fancyBox
       $("[data-fancybox='" + $.escapeSelector(url.gallery) + "']")
         .eq(url.index - 1)
-        .focus()
+        .trigger("focus")
         .trigger("click.fb-start");
     }
   }


### PR DESCRIPTION
Replaced .focus() with .trigger("focus") in triggerFromUrl() in hash.js.
jQueryMigrate fires a `JQMIGRATE: jQuery.fn.focus() event shorthand is deprecated` warning for this line with jQuery 3.

As far as I can tell this was an oversight, all other occurrences have already been fixed to use .trigger() (despite the unluckily named .focus() methods of the Thumbs instance).