### PR TITLE
Fix for thumbnail url that contains parentheses

### DIFF
--- a/src/js/thumbs.js
+++ b/src/js/thumbs.js
@@ -111,7 +111,7 @@
           '<a href="javascript:;" tabindex="0" data-index="' +
           i +
           '"' +
-          (src && src.length ? ' style="background-image:url(' + src + ')"' : 'class="fancybox-thumbs-missing"') +
+          (src && src.length ? ' style="background-image:url(\'' + src + '\')"' : 'class="fancybox-thumbs-missing"') +
           "></a>"
         );
       });


### PR DESCRIPTION
Thumbnails are not displayed for image names containing parentheses, for example, for images with the names “slide (1).jpg”, “slide (2).jpg”, etc. the thumbnail will not be displayed.
![SharedScreenshot](https://user-images.githubusercontent.com/30486581/81838376-ff4fe500-9580-11ea-9c21-4abd058241bc.jpg)
