### PR TITLE
Prevent keyboard shortcuts in *[contenteditable]

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -936,7 +936,7 @@
         // Enable keyboard navigation
         // ==========================
 
-        if (!current.opts.keyboard || e.ctrlKey || e.altKey || e.shiftKey || $(e.target).is("input,textarea,video,audio,select")) {
+        if (!current.opts.keyboard || e.ctrlKey || e.altKey || e.shiftKey || $(e.target).is("input,textarea,video,audio,select,*[contenteditable]")) {
           return;
         }
 


### PR DESCRIPTION
In addition to other input type elements, also prevent keyboard shortcuts while inside any element with a contenteditable attribute.