### PR TITLE
docs: Fix simple typo, transiton -> transition

### DIFF
--- a/dist/jquery.fancybox.js
+++ b/dist/jquery.fancybox.js
@@ -2461,7 +2461,7 @@
         return;
       }
 
-      // Prepare for CSS transiton
+      // Prepare for CSS transition
       // =========================
       $.fancybox.stop($slide);
 
@@ -2553,7 +2553,7 @@
 
         self.preload("inline");
 
-        // Trigger any CSS transiton inside the slide
+        // Trigger any CSS transition inside the slide
         forceRedraw(current.$slide);
 
         current.$slide.addClass("fancybox-slide--complete");

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -2451,7 +2451,7 @@
         return;
       }
 
-      // Prepare for CSS transiton
+      // Prepare for CSS transition
       // =========================
       $.fancybox.stop($slide);
 
@@ -2543,7 +2543,7 @@
 
         self.preload("inline");
 
-        // Trigger any CSS transiton inside the slide
+        // Trigger any CSS transition inside the slide
         forceRedraw(current.$slide);
 
         current.$slide.addClass("fancybox-slide--complete");


### PR DESCRIPTION
There is a small typo in dist/jquery.fancybox.js, src/js/core.js.

Should read `transition` rather than `transiton`.

