### PR TITLE
fixing youtube

### DIFF
--- a/dist/jquery.fancybox.js
+++ b/dist/jquery.fancybox.js
@@ -3445,7 +3445,7 @@
   // Object containing properties for each media type
   var defaults = {
     youtube: {
-      matcher: /(youtube\.com|youtu\.be|youtube\-nocookie\.com)\/(watch\?(.*&)?v=|v\/|u\/|embed\/?)?(videoseries\?list=(.*)|[\w-]{11}|\?listType=(.*)&list=(.*))(.*)/i,
+      matcher: /(youtube\.com|youtu\.be)\/(watch\?(.*&)?v=|v\/|u\/|embed\/?)?(videoseries\?list=(.*)|[\w-]{11}|\?listType=(.*)&list=(.*))(.*)/i,
       params: {
         autoplay: 1,
         autohide: 1,
@@ -3458,7 +3458,7 @@
       },
       paramPlace: 8,
       type: "iframe",
-      url: "https://www.youtube-nocookie.com/embed/$4",
+      url: "https://www.youtube.com/embed/$4",
       thumb: "https://img.youtube.com/vi/$4/hqdefault.jpg"
     },
 


### PR DESCRIPTION
youtube embed is error
like this
The webpage at https://www.youtube-nocookie.com/embed/_sI_Ps7JSEk?autoplay=1&autohide=1&fs=1&rel=0&hd=1&wmode=transparent&enablejsapi=1&html5=1 might be temporarily down or it may have moved permanently to a new web address.

i was remove -nocookie and that is play
![Screenshot from 2020-10-13 12-02-05](https://user-images.githubusercontent.com/44237629/95817561-f0e24100-0d4b-11eb-9e08-97f77e34041e.png)
 normally again