### PR TITLE
Disable keyboard keys for contenteditable and more

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -936,7 +936,7 @@
         // Enable keyboard navigation
         // ==========================
 
-        if (!current.opts.keyboard || e.ctrlKey || e.altKey || e.shiftKey || $(e.target).is("input,textarea,video,audio,select")) {
+        if (!current.opts.keyboard || e.ctrlKey || e.altKey || e.shiftKey || $(e.target).is("input,textarea,video,audio,select,[contenteditable]")) {
           return;
         }
 

--- a/src/js/fullscreen.js
+++ b/src/js/fullscreen.js
@@ -157,7 +157,7 @@
 
     "afterKeydown.fb": function (e, instance, current, keypress, keycode) {
       // "F"
-      if (instance && instance.FullScreen && keycode === 70) {
+      if (instance && instance.FullScreen && keycode === 70 && !$(document.activeElement).is("input,textarea,video,audio,select,[contenteditable]")) {
         keypress.preventDefault();
 
         instance.FullScreen.toggle();

--- a/src/js/slideshow.js
+++ b/src/js/slideshow.js
@@ -173,7 +173,7 @@
       var SlideShow = instance && instance.SlideShow;
 
       // "P" or Spacebar
-      if (SlideShow && current.opts.slideShow && (keycode === 80 || keycode === 32) && !$(document.activeElement).is("button,a,input")) {
+      if (SlideShow && current.opts.slideShow && (keycode === 80 || keycode === 32) && !$(document.activeElement).is("button,a,input,textarea,video,audio,select,[contenteditable]")) {
         keypress.preventDefault();
 
         SlideShow.toggle();

--- a/src/js/thumbs.js
+++ b/src/js/thumbs.js
@@ -233,7 +233,7 @@
       var Thumbs = instance && instance.Thumbs;
 
       // "G"
-      if (Thumbs && Thumbs.isActive && keycode === 71) {
+      if (Thumbs && Thumbs.isActive && keycode === 71 && !$(document.activeElement).is("input,textarea,video,audio,select,[contenteditable]")) {
         keypress.preventDefault();
 
         Thumbs.toggle();


### PR DESCRIPTION
I excluded these fields for the keyboard shortcuts: `input,textarea,video,audio,select,[contenteditable]`

For example, the CkEditor 5 uses a div with contenteditable.

Example of an element:
```html
<div contenteditable="true">...</div>
```
