### PR TITLE
Include share.js in gulp file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,6 +30,7 @@ gulp.task("scripts", function() {
       "src/js/core.js",
       "src/js/media.js",
       "src/js/guestures.js",
+      "src/js/share.js",
       "src/js/slideshow.js",
       "src/js/fullscreen.js",
       "src/js/thumbs.js",


### PR DESCRIPTION
Shouldn't `share.js` be included in gulp file?

To test that I had to upgrade to gulp 4.
No error messages were shown on the console, but on the website:
`Uncaught TypeError: $.fancybox.defaults.share is undefined`

When I included `share.js` it worked again.
It could of course be that what is different at gulp 4.

Gulp 4 Pull Request: https://github.com/fancyapps/fancybox/pull/2578