### PR TITLE
Update to gulp 4.0.2

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,4 +65,4 @@ gulp.task("css", function() {
 });
 
 // Default Task
-gulp.task("default", ["scripts", "css"]);
+gulp.task("default", gulp.parallel(["scripts", "css"]));

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "del": "^2.2.2",
-    "gulp": "^3.9.1",
+    "gulp": "^4.0.2",
     "gulp-autoprefixer": "^3.1.1",
     "gulp-concat": "^2.6.1",
     "gulp-cssnano": "^2.1.2",


### PR DESCRIPTION
When I wanted to test something I got this error:
`ReferenceError: primordials is not defined in node`

It looks like Gulp 3 is not compatible with my node version. 
The same applies to Gulp 4. It is better if you test it yourself.

I also need to add `share.js` include so that I could generate the build: https://github.com/fancyapps/fancybox/pull/2576

You can decide whether to build with "series" or "parallel":

```javascript
gulp.task("default", gulp.series(["scripts", "css"]));
gulp.task("default", gulp.parallel(["scripts", "css"]));
```
